### PR TITLE
Add emergency holiday parsing to handle bad json data

### DIFF
--- a/caltrain/Makefile
+++ b/caltrain/Makefile
@@ -1,0 +1,8 @@
+
+.PHONY: test
+test:
+	go test ./... -race -cover -coverprofile=c.out -count=1
+
+.PHONY: lint
+lint:
+	golangci-lint run

--- a/caltrain/json_holiday.go
+++ b/caltrain/json_holiday.go
@@ -15,3 +15,19 @@ type holidayJson struct {
 		} `json:"AvailabilityConditions"`
 	} `json:"Content"`
 }
+
+type holidayJsonAlt struct {
+	Content struct {
+		ServiceCalendar struct {
+			ID       string `json:"id"`
+			FromDate string `json:"FromDate"`
+			ToDate   string `json:"ToDate"`
+		} `json:"ServiceCalendar"`
+		AvailabilityConditions struct {
+			Version  string `json:"version"`
+			ID       string `json:"id"`
+			FromDate string `json:"FromDate"`
+			ToDate   string `json:"ToDate"`
+		} `json:"AvailabilityConditions"`
+	} `json:"Content"`
+}

--- a/caltrain/parser.go
+++ b/caltrain/parser.go
@@ -183,7 +183,20 @@ func parseHolidays(raw []byte) ([]time.Time, error) {
 	raw = bytes.TrimPrefix(raw, []byte("\xef\xbb\xbf"))
 	data := holidayJson{}
 	if err := json.Unmarshal(raw, &data); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal: %w", err)
+		// TEMPORARY: try to use the alt struct
+		data := holidayJsonAlt{}
+		if err := json.Unmarshal(raw, &data); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal: %w", err)
+
+		}
+		holiday := data.Content.AvailabilityConditions
+		id := strings.TrimPrefix(holiday.ID, "CT:")
+		date, err := time.Parse("2006-01-02", id)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse time value %s: %w", id, err)
+		}
+		return []time.Time{date}, nil
+		// return nil, fmt.Errorf("failed to unmarshal: %w", err)
 	}
 
 	holidays := data.Content.AvailabilityConditions


### PR DESCRIPTION
the holiday response does not have consistent data. this adds a patch for the case when there's only 1 holiday. 

also adds a makefile for easy testing/linting