### PR TITLE
Update station parser and add more verbose logging

### DIFF
--- a/caltrain/api_client.go
+++ b/caltrain/api_client.go
@@ -23,6 +23,8 @@ func (a *APILimitError) Error() string {
 type APIError struct {
 	Status string
 	Code   int
+	Url    string
+	Query  map[string]string
 }
 
 func (a *APIError) Error() string {
@@ -72,7 +74,7 @@ func (a *APIClient511) Get(ctx context.Context, url string, query map[string]str
 		if resp.StatusCode == http.StatusTooManyRequests {
 			return nil, &APILimitError{}
 		}
-		return nil, &APIError{Status: resp.Status, Code: resp.StatusCode}
+		return nil, &APIError{Status: resp.Status, Code: resp.StatusCode, Url: url, Query: query}
 	}
 
 	// TODO: return the number of tries left? It exists in the header under

--- a/caltrain/api_client.go
+++ b/caltrain/api_client.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+
+	"github.com/sirupsen/logrus"
 )
 
 // APILimitError is returned on a failed API request when the failure
@@ -20,6 +22,7 @@ func (a *APILimitError) Error() string {
 // than too many requests
 type APIError struct {
 	Status string
+	Code   int
 }
 
 func (a *APIError) Error() string {
@@ -64,11 +67,12 @@ func (a *APIClient511) Get(ctx context.Context, url string, query map[string]str
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		logrus.Debugf("API error - %s", resp.Status)
 		// return a specific error for too many requests
 		if resp.StatusCode == http.StatusTooManyRequests {
 			return nil, &APILimitError{}
 		}
-		return nil, &APIError{Status: resp.Status}
+		return nil, &APIError{Status: resp.Status, Code: resp.StatusCode}
 	}
 
 	// TODO: return the number of tries left? It exists in the header under

--- a/caltrain/caltrain.go
+++ b/caltrain/caltrain.go
@@ -258,9 +258,6 @@ func (c *CaltrainClient) GetStationStatus(ctx context.Context, stationName Stati
 		"api_key":  c.key,
 	}
 
-	logrus.Infof("Query: %+v", query)
-	fmt.Println("Query: %+v", query)
-
 	var cacheData []TrainStatus
 	var cacheTime time.Time
 	var cacheError error

--- a/caltrain/caltrain.go
+++ b/caltrain/caltrain.go
@@ -259,6 +259,7 @@ func (c *CaltrainClient) GetStationStatus(ctx context.Context, stationName Stati
 	}
 
 	logrus.Infof("Query: %+v", query)
+	fmt.Println("Query: %+v", query)
 
 	var cacheData []TrainStatus
 	var cacheTime time.Time

--- a/caltrain/caltrain.go
+++ b/caltrain/caltrain.go
@@ -515,7 +515,7 @@ func (c *CaltrainClient) getStationFromCode(code string) Station {
 	return 0
 }
 
-// // AllLines returns a slice of all available train lines
+// AllLines returns a slice of all available train lines
 func (c *CaltrainClient) AllLines() []Line {
 	c.lLock.RLock()
 	defer c.lLock.RUnlock()

--- a/caltrain/caltrain.go
+++ b/caltrain/caltrain.go
@@ -258,7 +258,7 @@ func (c *CaltrainClient) GetStationStatus(ctx context.Context, stationName Stati
 		"api_key":  c.key,
 	}
 
-	logrus.Debugf("Query: %+v", query)
+	logrus.Infof("Query: %+v", query)
 
 	var cacheData []TrainStatus
 	var cacheTime time.Time

--- a/caltrain/caltrain.go
+++ b/caltrain/caltrain.go
@@ -258,6 +258,8 @@ func (c *CaltrainClient) GetStationStatus(ctx context.Context, stationName Stati
 		"api_key":  c.key,
 	}
 
+	logrus.Debugf("Query: %+v", query)
+
 	var cacheData []TrainStatus
 	var cacheTime time.Time
 	var cacheError error

--- a/caltrain/caltrain.go
+++ b/caltrain/caltrain.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -77,6 +79,7 @@ func (c *CaltrainClient) Initialize(ctx context.Context) (e error) {
 // UpdateLines makes an API call to refresh the available lines. This should be
 // called before UpdateTimeTable to ensure the time table data is accurate
 func (c *CaltrainClient) UpdateLines(ctx context.Context) error {
+	logrus.Debug("Updating train lines...")
 	c.lLock.Lock()
 	defer c.lLock.Unlock()
 
@@ -100,10 +103,12 @@ func (c *CaltrainClient) UpdateLines(ctx context.Context) error {
 // UpdateTimeTable makes an API call to refresh the timetable data. This
 // should be called periodically to ensure correct information.
 func (c *CaltrainClient) UpdateTimeTable(ctx context.Context) error {
+	logrus.Debug("Updating time tables...")
 	c.ttLock.Lock()
 	defer c.ttLock.Unlock()
 	// request the timetable for each line
 	for _, line := range c.lines {
+		logrus.Debugf("Fetching time table for %s trains", line.Name)
 		query := map[string]string{
 			"operator_id": "CT",
 			"line_id":     line.Name,
@@ -133,6 +138,7 @@ func (c *CaltrainClient) UpdateTimeTable(ctx context.Context) error {
 // UpdateStations makes an API call to refresh the station information.
 // This should only need to be called during Initialization.
 func (c *CaltrainClient) UpdateStations(ctx context.Context) error {
+	logrus.Debug("Updating stations...")
 	c.sLock.Lock()
 	defer c.sLock.Unlock()
 
@@ -156,6 +162,7 @@ func (c *CaltrainClient) UpdateStations(ctx context.Context) error {
 // UpdateHolidays makes an API call to refresh the holiday data. This can
 // be updated multiple times a year so this should be called periodically.
 func (c *CaltrainClient) UpdateHolidays(ctx context.Context) error {
+	logrus.Debug("Updating holidays...")
 	c.sLock.Lock()
 	defer c.sLock.Unlock()
 
@@ -186,6 +193,7 @@ func (c *CaltrainClient) SetupCache(expire time.Duration) {
 // GetDelays makes an API call and returns a slice of TrainStatus who's
 // delay into their next station is greater than the time.Duration argument
 func (c *CaltrainClient) GetDelays(ctx context.Context, threshold time.Duration) ([]TrainStatus, time.Time, error) {
+	logrus.Debug("Checking for delayed trains...")
 	query := map[string]string{
 		"agency":  "CT",
 		"api_key": c.key,
@@ -238,6 +246,7 @@ func (c *CaltrainClient) GetDelays(ctx context.Context, threshold time.Duration)
 // GetStationStatus makes an API call and returns a slice of TrainsStatus
 // who have a status reported for the given station and direction.
 func (c *CaltrainClient) GetStationStatus(ctx context.Context, stationName Station, direction Direction) ([]TrainStatus, time.Time, error) {
+	logrus.Debugf("Getting station status for %s...", stationName.String())
 	t := time.Now()
 	code, err := c.getStationCode(stationName, direction)
 	if err != nil {
@@ -297,6 +306,7 @@ func (c *CaltrainClient) GetStationStatus(ctx context.Context, stationName Stati
 // from src to dst on the given weekday. It uses the cached timetable and
 // does not make an API call
 func (c *CaltrainClient) GetTrainsBetweenStationsForWeekday(ctx context.Context, src, dst Station, weekday time.Weekday) ([]*Route, error) {
+	logrus.Debugf("Getting trains between stations '%s' and '%s' for a '%s'", src.String(), dst.String(), weekday.String())
 	c.ttLock.RLock()
 	defer c.ttLock.RUnlock()
 

--- a/caltrain/caltrain.go
+++ b/caltrain/caltrain.go
@@ -96,6 +96,9 @@ func (c *CaltrainClient) UpdateLines(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse lines: %w", err)
 	}
+	if len(lines) == 0 {
+		return errors.New("unable to populate the lines: none found")
+	}
 	c.lines = lines
 	return nil
 }
@@ -132,6 +135,10 @@ func (c *CaltrainClient) UpdateTimeTable(ctx context.Context) error {
 		}
 	}
 
+	if len(c.timetable) == 0 {
+		return errors.New("unable to populate the timetables: none found")
+	}
+
 	return nil
 }
 
@@ -154,6 +161,9 @@ func (c *CaltrainClient) UpdateStations(ctx context.Context) error {
 	stations, err := parseStations(data)
 	if err != nil {
 		return fmt.Errorf("failed to parse stations: %w", err)
+	}
+	if len(stations) == 0 {
+		return errors.New("unable to populate the station list: none found")
 	}
 	c.stations = stations
 	return nil

--- a/caltrain/caltrain.go
+++ b/caltrain/caltrain.go
@@ -111,7 +111,7 @@ func (c *CaltrainClient) UpdateTimeTable(ctx context.Context) error {
 		logrus.Debugf("Fetching time table for %s trains", line.Name)
 		query := map[string]string{
 			"operator_id": "CT",
-			"line_id":     line.Name,
+			"line_id":     line.Id,
 			"api_key":     c.key,
 		}
 		data, err := c.APIClient.Get(ctx, timetableURL, query)

--- a/caltrain/caltrain_test.go
+++ b/caltrain/caltrain_test.go
@@ -14,12 +14,12 @@ const (
 )
 
 var allLines []Line = []Line{
-	Line{Id: "Local", Name: "Local"},
-	Line{Id: "Limited", Name: "Limited"},
-	Line{Id: "LTD A", Name: "Limited A"},
-	Line{Id: "LTD B", Name: "Limited B"},
-	Line{Id: "Bullet", Name: "Bullet"},
-	Line{Id: "Special", Name: "Special"},
+	{Id: "Local", Name: "Local"},
+	{Id: "Limited", Name: "Limited"},
+	{Id: "LTD A", Name: "Limited A"},
+	{Id: "LTD B", Name: "Limited B"},
+	{Id: "Bullet", Name: "Bullet"},
+	{Id: "Special", Name: "Special"},
 }
 
 func TestGetStations(t *testing.T) {

--- a/caltrain/json_station.go
+++ b/caltrain/json_station.go
@@ -6,17 +6,22 @@ type stationJson struct {
 		DataObjects       struct {
 			ID                 string               `json:"id"`
 			ScheduledStopPoint []scheduledStopPoint `json:"ScheduledStopPoint"`
-			StopAreas          interface{}          `json:"stopAreas"`
 		} `json:"dataObjects"`
 	} `json:"Contents"`
 }
 
 type scheduledStopPoint struct {
-	ID       string `json:"id"`
+	ID         string `json:"id"`
+	Extensions struct {
+		LocationType  string      `json:"LocationType"`
+		PlatformCode  interface{} `json:"PlatformCode"`
+		ParentStation interface{} `json:"ParentStation"`
+	} `json:"Extensions"`
 	Name     string `json:"Name"`
 	Location struct {
 		Longitude string `json:"Longitude"`
 		Latitude  string `json:"Latitude"`
 	} `json:"Location"`
-	StopType string `json:"StopType"`
+	URL      interface{} `json:"Url"`
+	StopType string      `json:"StopType"`
 }

--- a/caltrain/parser.go
+++ b/caltrain/parser.go
@@ -140,10 +140,12 @@ func parseStations(raw []byte) (map[Station]*stationInfo, error) {
 	// that gets us halfway there first, then convert to our struct
 	stops := data.Contents.DataObjects.ScheduledStopPoint
 	for _, stop := range stops {
-		if strings.HasSuffix(stop.Name, "Station") {
+		if stop.ID == "777403" || stop.ID == "777402" {
+			// Skip the Tamien and San Jose stations that are an outlier for some reason
 			continue
 		}
-		name, err := ParseStation(strings.TrimSuffix(stop.Name, " Caltrain"))
+
+		name, err := ParseStation(strings.TrimSuffix(stop.Name, " Caltrain Station"))
 		if err != nil {
 			return ret, fmt.Errorf("failed to parse station: %w", err)
 		}

--- a/caltrain/parser_test.go
+++ b/caltrain/parser_test.go
@@ -237,9 +237,9 @@ func TestParseLines(t *testing.T) {
 	}
 
 	exp := []Line{
-		Line{Id: "Local", Name: "Local"},
-		Line{Id: "LTD A", Name: "Limited A"},
-		Line{Id: "LTD B", Name: "Limited B"},
+		{Id: "Local", Name: "Local"},
+		{Id: "LTD A", Name: "Limited A"},
+		{Id: "LTD B", Name: "Limited B"},
 	}
 
 	lines, err := parseLines(data)

--- a/caltrain/testdata/stations.json
+++ b/caltrain/testdata/stations.json
@@ -1,605 +1,1000 @@
 {
-  "Contents": {
-    "ResponseTimestamp": "2020-01-07T21:53:33-08:00",
-    "dataObjects": {
-      "id": "CT",
-      "ScheduledStopPoint": [
-        {
-          "id": "70022",
-          "Name": "22nd Street Caltrain",
-          "Location": {
-            "Longitude": "-122.392404",
-            "Latitude": "37.757583"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70021",
-          "Name": "22nd Street Caltrain",
-          "Location": {
-            "Longitude": "-122.39188",
-            "Latitude": "37.757599"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70151",
-          "Name": "Atherton Caltrain",
-          "Location": {
-            "Longitude": "-122.19779",
-            "Latitude": "37.464645"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70152",
-          "Name": "Atherton Caltrain",
-          "Location": {
-            "Longitude": "-122.197869",
-            "Latitude": "37.464584"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70031",
-          "Name": "Bayshore Caltrain",
-          "Location": {
-            "Longitude": "-122.401586",
-            "Latitude": "37.709537"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70032",
-          "Name": "Bayshore Caltrain",
-          "Location": {
-            "Longitude": "-122.40198",
-            "Latitude": "37.709544"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70121",
-          "Name": "Belmont Caltrain",
-          "Location": {
-            "Longitude": "-122.275738",
-            "Latitude": "37.52089"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70122",
-          "Name": "Belmont Caltrain",
-          "Location": {
-            "Longitude": "-122.275816",
-            "Latitude": "37.520844"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70292",
-          "Name": "Blossom Hill Caltrain",
-          "Location": {
-            "Longitude": "-121.797683",
-            "Latitude": "37.252379"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70291",
-          "Name": "Blossom Hill Caltrain",
-          "Location": {
-            "Longitude": "-121.797643",
-            "Latitude": "37.252422"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70071",
-          "Name": "Broadway Caltrain",
-          "Location": {
-            "Longitude": "-122.36265",
-            "Latitude": "37.58764"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70072",
-          "Name": "Broadway Caltrain",
-          "Location": {
-            "Longitude": "-122.362708",
-            "Latitude": "37.587552"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70082",
-          "Name": "Burlingame Caltrain",
-          "Location": {
-            "Longitude": "-122.345075",
-            "Latitude": "37.580186"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70081",
-          "Name": "Burlingame Caltrain",
-          "Location": {
-            "Longitude": "-122.3449",
-            "Latitude": "37.580197"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70191",
-          "Name": "California Ave Caltrain",
-          "Location": {
-            "Longitude": "-122.141927",
-            "Latitude": "37.429365"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70192",
-          "Name": "California Ave Caltrain",
-          "Location": {
-            "Longitude": "-122.141978",
-            "Latitude": "37.429333"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70282",
-          "Name": "Capitol Caltrain",
-          "Location": {
-            "Longitude": "-121.842037",
-            "Latitude": "37.284062"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70281",
-          "Name": "Capitol Caltrain",
-          "Location": {
-            "Longitude": "-121.841955",
-            "Latitude": "37.284102"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70252",
-          "Name": "College Park Caltrain",
-          "Location": {
-            "Longitude": "-121.914677",
-            "Latitude": "37.342338"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70251",
-          "Name": "College Park Caltrain",
-          "Location": {
-            "Longitude": "-121.9146",
-            "Latitude": "37.342384"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70322",
-          "Name": "Gilroy Caltrain",
-          "Location": {
-            "Longitude": "-121.566225",
-            "Latitude": "37.003485"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70321",
-          "Name": "Gilroy Caltrain",
-          "Location": {
-            "Longitude": "-121.566088",
-            "Latitude": "37.003538"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70101",
-          "Name": "Hayward Park Caltrain",
-          "Location": {
-            "Longitude": "-122.309338",
-            "Latitude": "37.552938"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70102",
-          "Name": "Hayward Park Caltrain",
-          "Location": {
-            "Longitude": "-122.309608",
-            "Latitude": "37.552994"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70111",
-          "Name": "Hillsdale Caltrain",
-          "Location": {
-            "Longitude": "-122.297349",
-            "Latitude": "37.537868"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70112",
-          "Name": "Hillsdale Caltrain",
-          "Location": {
-            "Longitude": "-122.297461",
-            "Latitude": "37.537814"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70231",
-          "Name": "Lawrence Caltrain",
-          "Location": {
-            "Longitude": "-121.997114",
-            "Latitude": "37.370598"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70232",
-          "Name": "Lawrence Caltrain",
-          "Location": {
-            "Longitude": "-121.997135",
-            "Latitude": "37.370484"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70161",
-          "Name": "Menlo Park Caltrain",
-          "Location": {
-            "Longitude": "-122.182297",
-            "Latitude": "37.454856"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70162",
-          "Name": "Menlo Park Caltrain",
-          "Location": {
-            "Longitude": "-122.182405",
-            "Latitude": "37.454745"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70062",
-          "Name": "Millbrae Caltrain",
-          "Location": {
-            "Longitude": "-122.386832",
-            "Latitude": "37.599797"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70061",
-          "Name": "Millbrae Caltrain",
-          "Location": {
-            "Longitude": "-122.386647",
-            "Latitude": "37.59988"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70302",
-          "Name": "Morgan Hill Caltrain",
-          "Location": {
-            "Longitude": "-121.650304",
-            "Latitude": "37.129321"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70301",
-          "Name": "Morgan Hill Caltrain",
-          "Location": {
-            "Longitude": "-121.650244",
-            "Latitude": "37.129363"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70211",
-          "Name": "Mountain View Caltrain",
-          "Location": {
-            "Longitude": "-122.075956",
-            "Latitude": "37.394459"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70212",
-          "Name": "Mountain View Caltrain",
-          "Location": {
-            "Longitude": "-122.075994",
-            "Latitude": "37.394402"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70172",
-          "Name": "Palo Alto Caltrain",
-          "Location": {
-            "Longitude": "-122.164697",
-            "Latitude": "37.443405"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70171",
-          "Name": "Palo Alto Caltrain",
-          "Location": {
-            "Longitude": "-122.164614",
-            "Latitude": "37.443475"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70142",
-          "Name": "Redwood City Caltrain",
-          "Location": {
-            "Longitude": "-122.232",
-            "Latitude": "37.486101"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70141",
-          "Name": "Redwood City Caltrain",
-          "Location": {
-            "Longitude": "-122.231936",
-            "Latitude": "37.486159"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70201",
-          "Name": "San Antonio Caltrain",
-          "Location": {
-            "Longitude": "-122.107069",
-            "Latitude": "37.407323"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70202",
-          "Name": "San Antonio Caltrain",
-          "Location": {
-            "Longitude": "-122.107125",
-            "Latitude": "37.407277"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70051",
-          "Name": "San Bruno Caltrain",
-          "Location": {
-            "Longitude": "-122.411968",
-            "Latitude": "37.631128"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70052",
-          "Name": "San Bruno Caltrain",
-          "Location": {
-            "Longitude": "-122.412076",
-            "Latitude": "37.631108"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70131",
-          "Name": "San Carlos Caltrain",
-          "Location": {
-            "Longitude": "-122.26015",
-            "Latitude": "37.50805"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70132",
-          "Name": "San Carlos Caltrain",
-          "Location": {
-            "Longitude": "-122.260266",
-            "Latitude": "37.507933"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70011",
-          "Name": "San Francisco Caltrain",
-          "Location": {
-            "Longitude": "-122.394992",
-            "Latitude": "37.77639"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70012",
-          "Name": "San Francisco Caltrain",
-          "Location": {
-            "Longitude": "-122.394935",
-            "Latitude": "37.776348"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "777402",
-          "Name": "San Jose Caltrain Station",
-          "Location": {
-            "Longitude": "-121.901985",
-            "Latitude": "37.330196"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70261",
-          "Name": "San Jose Diridon Caltrain",
-          "Location": {
-            "Longitude": "-121.903011",
-            "Latitude": "37.329239"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70262",
-          "Name": "San Jose Diridon Caltrain",
-          "Location": {
-            "Longitude": "-121.903173",
-            "Latitude": "37.329231"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70311",
-          "Name": "San Martin Caltrain",
-          "Location": {
-            "Longitude": "-121.610049",
-            "Latitude": "37.085225"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70312",
-          "Name": "San Martin Caltrain",
-          "Location": {
-            "Longitude": "-121.610936",
-            "Latitude": "37.086653"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70091",
-          "Name": "San Mateo Caltrain",
-          "Location": {
-            "Longitude": "-122.323851",
-            "Latitude": "37.568087"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70092",
-          "Name": "San Mateo Caltrain",
-          "Location": {
-            "Longitude": "-122.324092",
-            "Latitude": "37.568294"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70242",
-          "Name": "Santa Clara Caltrain",
-          "Location": {
-            "Longitude": "-121.936135",
-            "Latitude": "37.353189"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70241",
-          "Name": "Santa Clara Caltrain",
-          "Location": {
-            "Longitude": "-121.93608",
-            "Latitude": "37.353238"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70041",
-          "Name": "South San Francisco Caltrain",
-          "Location": {
-            "Longitude": "-122.40487",
-            "Latitude": "37.65589"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70042",
-          "Name": "South San Francisco Caltrain",
-          "Location": {
-            "Longitude": "-122.405018",
-            "Latitude": "37.655946"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "2537744",
-          "Name": "Stanford Caltrain",
-          "Location": {
-            "Longitude": "-122.156501991",
-            "Latitude": "37.4384454676"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "2537740",
-          "Name": "Stanford Caltrain",
-          "Location": {
-            "Longitude": "-122.156443",
-            "Latitude": "37.438516"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70222",
-          "Name": "Sunnyvale Caltrain",
-          "Location": {
-            "Longitude": "-122.031423",
-            "Latitude": "37.378789"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70221",
-          "Name": "Sunnyvale Caltrain",
-          "Location": {
-            "Longitude": "-122.031372",
-            "Latitude": "37.378916"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70272",
-          "Name": "Tamien Caltrain",
-          "Location": {
-            "Longitude": "-121.883999",
-            "Latitude": "37.31175"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "70271",
-          "Name": "Tamien Caltrain",
-          "Location": {
-            "Longitude": "-121.883721",
-            "Latitude": "37.31174"
-          },
-          "StopType": "onstreetBus"
-        },
-        {
-          "id": "777403",
-          "Name": "Tamien Caltrain Station",
-          "Location": {
-            "Longitude": "-121.883403",
-            "Latitude": "37.311638"
-          },
-          "StopType": "onstreetBus"
+    "Contents": {
+        "ResponseTimestamp": "2021-08-03T19:19:53-07:00",
+        "dataObjects": {
+            "id": "CT",
+            "ScheduledStopPoint": [
+                {
+                    "id": "70022",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "22nd Street Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.392404",
+                        "Latitude": "37.757583"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70021",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "22nd Street Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.39188",
+                        "Latitude": "37.757599"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70151",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Atherton Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.19779",
+                        "Latitude": "37.464645"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70152",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Atherton Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.197869",
+                        "Latitude": "37.464584"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70031",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Bayshore Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.401586",
+                        "Latitude": "37.709537"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70032",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Bayshore Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.40198",
+                        "Latitude": "37.709544"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70122",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Belmont Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.275816",
+                        "Latitude": "37.520844"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70121",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Belmont Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.275738",
+                        "Latitude": "37.52089"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70291",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Blossom Hill Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.797643",
+                        "Latitude": "37.252422"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70292",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Blossom Hill Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.797683",
+                        "Latitude": "37.252379"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70072",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Broadway Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.362708",
+                        "Latitude": "37.587552"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70071",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Broadway Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.36265",
+                        "Latitude": "37.58764"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70082",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Burlingame Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.345075",
+                        "Latitude": "37.580186"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70081",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Burlingame Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.3449",
+                        "Latitude": "37.580197"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70192",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "California Ave Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.141978",
+                        "Latitude": "37.429333"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70191",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "California Ave Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.141927",
+                        "Latitude": "37.429365"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70282",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Capitol Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.842037",
+                        "Latitude": "37.284062"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70281",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Capitol Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.841955",
+                        "Latitude": "37.284102"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70252",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "College Park Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.914677",
+                        "Latitude": "37.342338"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70251",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "College Park Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.9146",
+                        "Latitude": "37.342384"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70321",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Gilroy Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.566088",
+                        "Latitude": "37.003538"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70322",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Gilroy Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.566225",
+                        "Latitude": "37.003485"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70102",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Hayward Park Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.309608",
+                        "Latitude": "37.552994"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70101",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Hayward Park Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.309338",
+                        "Latitude": "37.552938"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70112",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Hillsdale Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.301666",
+                        "Latitude": "37.542536"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70111",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Hillsdale Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.3014966366",
+                        "Latitude": "37.542607659"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70232",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Lawrence Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.997135",
+                        "Latitude": "37.370484"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70231",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Lawrence Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.997114",
+                        "Latitude": "37.370598"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70162",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Menlo Park Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.182405",
+                        "Latitude": "37.454745"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70161",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Menlo Park Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.182297",
+                        "Latitude": "37.454856"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70061",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Millbrae Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.386647",
+                        "Latitude": "37.59988"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70062",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Millbrae Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.386832",
+                        "Latitude": "37.599797"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70302",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Morgan Hill Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.650304",
+                        "Latitude": "37.129321"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70301",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Morgan Hill Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.650244",
+                        "Latitude": "37.129363"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70211",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Mountain View Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.075956",
+                        "Latitude": "37.394459"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70212",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Mountain View Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.075994",
+                        "Latitude": "37.394402"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70172",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Palo Alto Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.164697",
+                        "Latitude": "37.443405"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70171",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Palo Alto Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.164614",
+                        "Latitude": "37.443475"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70141",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Redwood City Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.231936",
+                        "Latitude": "37.486159"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70142",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Redwood City Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.232",
+                        "Latitude": "37.486101"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70201",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "San Antonio Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.107069",
+                        "Latitude": "37.407323"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70202",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "San Antonio Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.107125",
+                        "Latitude": "37.407277"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70051",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "San Bruno Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.411968",
+                        "Latitude": "37.631128"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70052",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "San Bruno Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.412076",
+                        "Latitude": "37.631108"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70131",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "San Carlos Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.26015",
+                        "Latitude": "37.50805"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70132",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "San Carlos Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.260266",
+                        "Latitude": "37.507933"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70012",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "San Francisco Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.394935",
+                        "Latitude": "37.776348"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70011",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "San Francisco Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.394992",
+                        "Latitude": "37.77639"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "777402",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "San Jose Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.901985",
+                        "Latitude": "37.330196"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70262",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "San Jose Diridon Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.903173",
+                        "Latitude": "37.329231"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70261",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "San Jose Diridon Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.903011",
+                        "Latitude": "37.329239"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70312",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "San Martin Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.610936",
+                        "Latitude": "37.086653"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70311",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "San Martin Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.610049",
+                        "Latitude": "37.085225"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70092",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "San Mateo Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.324092",
+                        "Latitude": "37.568294"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70091",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "San Mateo Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.323851",
+                        "Latitude": "37.568087"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70241",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Santa Clara Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.93608",
+                        "Latitude": "37.353238"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70242",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Santa Clara Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.936135",
+                        "Latitude": "37.353189"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70041",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "South San Francisco Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.40487",
+                        "Latitude": "37.65589"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70042",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "South San Francisco Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.405018",
+                        "Latitude": "37.655946"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "2537744",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Stanford Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.156501991",
+                        "Latitude": "37.4384454676"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "2537740",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Stanford Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.156443",
+                        "Latitude": "37.438516"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70222",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Sunnyvale Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.031423",
+                        "Latitude": "37.378789"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70221",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Sunnyvale Caltrain Station",
+                    "Location": {
+                        "Longitude": "-122.031372",
+                        "Latitude": "37.378916"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "777403",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Tamien Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.883403",
+                        "Latitude": "37.311638"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70271",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Tamien Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.883721",
+                        "Latitude": "37.31174"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                },
+                {
+                    "id": "70272",
+                    "Extensions": {
+                        "LocationType": "0",
+                        "PlatformCode": null,
+                        "ParentStation": null
+                    },
+                    "Name": "Tamien Caltrain Station",
+                    "Location": {
+                        "Longitude": "-121.883999",
+                        "Latitude": "37.31175"
+                    },
+                    "Url": null,
+                    "StopType": "onstreetBus"
+                }
+            ]
         }
-      ],
-      "stopAreas": null
     }
-  }
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/efritz09/go-caltrain
 
 go 1.16
 
-require github.com/benbjohnson/clock v1.1.0
+require (
+	github.com/benbjohnson/clock v1.1.0
+	github.com/sirupsen/logrus v1.8.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
This PR fixes the breaking changes introduced by an API change, adds debug level logging, and checks that lines, stations, and timetables exist before returning after the init