### PR TITLE
Use Line ID rather than Line Name for timetable storage

### DIFF
--- a/caltrain/caltrain.go
+++ b/caltrain/caltrain.go
@@ -461,7 +461,7 @@ func (c *CaltrainClient) getLine(id string) (Line, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("unknown line ID %s", id)
+	return Line{}, fmt.Errorf("unknown line ID %s", id)
 }
 
 // getRouteCodes returns the proper station codes for a route given a

--- a/caltrain/caltrain.go
+++ b/caltrain/caltrain.go
@@ -111,7 +111,7 @@ func (c *CaltrainClient) UpdateTimeTable(ctx context.Context) error {
 	defer c.ttLock.Unlock()
 	// request the timetable for each line
 	for _, line := range c.lines {
-		logrus.Debugf("Fetching time table for %s trains", line.Name)
+		logrus.Debugf("Fetching time table for %s-%s trains", line.Id, line.Name)
 		query := map[string]string{
 			"operator_id": "CT",
 			"line_id":     line.Id,
@@ -127,7 +127,7 @@ func (c *CaltrainClient) UpdateTimeTable(ctx context.Context) error {
 			return fmt.Errorf("failed to parse timetable: %w", err)
 		}
 		// store the timetable
-		c.timetable[line.Name] = journeys
+		c.timetable[line.Id] = journeys
 
 		// overwrite the known data with the timetable's ServiceCalendarFrame
 		for key, value := range services {
@@ -447,6 +447,21 @@ func (c *CaltrainClient) getStationCode(st Station, dir Direction) (string, erro
 	} else {
 		return "", fmt.Errorf("unknown direction %s", dir)
 	}
+}
+
+// getLine returns a Line struc for a given line ID
+func (c *CaltrainClient) getLine(id string) (Line, error) {
+	// first validate the direction
+	c.lLock.RLock()
+	defer c.lLock.RUnlock()
+
+	for _, l := range c.lines {
+		if l.Id == id {
+			return l, nil
+		}
+	}
+
+	return nil, fmt.Errorf("unknown line ID %s", id)
 }
 
 // getRouteCodes returns the proper station codes for a route given a

--- a/caltrain/timetable.go
+++ b/caltrain/timetable.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 // timetable.go contains helpers relating to the timetable. All functions must
@@ -26,7 +28,14 @@ func (c *CaltrainClient) getTimetableForStation(stationCode string, dir Directio
 
 	weekday := strings.ToLower(day.String())
 
-	for line, ttArray := range c.timetable {
+	for lineId, ttArray := range c.timetable {
+		line, err := c.getLine(lineId)
+		if err != nil {
+			logrus.Errorf("failed to get line!")
+			line := Line{Id: "unknown", Name: "Unknown"}
+		} else {
+			logrus.Debugf("getting line %s-%s for station code %s...", line.Id, line.Name, stationCode)
+		}
 		for _, frame := range ttArray {
 			// Check the day reference
 			if !c.isForToday(weekday, frame.FrameValidityConditions.AvailabilityCondition.DayTypes.DayTypeRef.Ref) {
@@ -40,7 +49,7 @@ func (c *CaltrainClient) getTimetableForStation(stationCode string, dir Directio
 			journeys := frame.VehicleJourneys.TimetableRouteJourney
 			for _, journey := range journeys {
 				if isStationInJourney(stationCode, journey) {
-					journey.Line = line
+					journey.Line = line.Name
 					allJourneys = append(allJourneys, journey)
 				}
 			}

--- a/caltrain/timetable.go
+++ b/caltrain/timetable.go
@@ -32,7 +32,7 @@ func (c *CaltrainClient) getTimetableForStation(stationCode string, dir Directio
 		line, err := c.getLine(lineId)
 		if err != nil {
 			logrus.Errorf("failed to get line!")
-			line := Line{Id: "unknown", Name: "Unknown"}
+			line = Line{Id: "unknown", Name: "Unknown"}
 		} else {
 			logrus.Debugf("getting line %s-%s for station code %s...", line.Id, line.Name, stationCode)
 		}


### PR DESCRIPTION
The 511 API has changed such that Line names are no longer unique, this changes the timetable storage to use the unique Line ID as storage and query rather than the Name